### PR TITLE
show initial checked values

### DIFF
--- a/dist/ionic-multiselect.js
+++ b/dist/ionic-multiselect.js
@@ -268,9 +268,17 @@ angular.module("ionic-multiselect", [])
         /**
         * @name validate
         * @desc Validates the current list
-        * @param {Object} item: Object data item
         */
-        scope.validate = function(item) {
+        scope.validate = function() {
+          scope.fetchCheckedItems();
+          scope.hideItems();
+        };
+
+        /**
+         * @name fetchCheckedItems
+         * @desc parses the items array and determines which items are checked
+         */
+        scope.fetchCheckedItems = function() {
           scope.value = [];
           if (scope.items) {
             var arrChecked = [];
@@ -285,17 +293,22 @@ angular.module("ionic-multiselect", [])
 
             scope.itemChecked = arrChecked;
           }
-          scope.hideItems();
-        };
+        }
 
         // Watch itemChecked property
         scope.$watch(function(){
           return scope.itemChecked;
         }, scope.onCheckValueChanged, true);
 
+        // Watch value property
         scope.$watch(function(){
           return scope.value;
         }, scope.onValueChanged, true);
+
+        // Watch items property
+        scope.$watch(function(){
+          return scope.items;
+        }, scope.fetchCheckedItems, true);
       }
     };
   }]);


### PR DESCRIPTION
closes #14 

The real problem here is that the checked values were being validated before the items array actually had any values (in my case fetched over an API). So this change adds a $watcher for items to revalidate the checked values any time the items array changes.