### PR TITLE
Fixed modal-template (ion-list was wrongly closed)

### DIFF
--- a/dist/templates/modal-template.html
+++ b/dist/templates/modal-template.html
@@ -18,6 +18,6 @@
           {{ $eval('item.' + textProperty) }} 
         </div>
       </ion-item>
-    </div>
+    </ion-list>
   </ion-content>
 </ion-modal-view>


### PR DESCRIPTION
Updated `dist/templates/modal-template.html` to fix a bug where `<ion-list>` was wrongly closed using `</div>` tag instead of `</ion-list>`