### PR TITLE
Implement better default values strategy based on scope.valueProperty:

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ Attributes
 12. default-value
 
     Type: Array
-	A list of items that is default to the select.
+	A list of values (from the value-property) that is default to the select
 
 Example
 -------

--- a/dist/ionic-multiselect.js
+++ b/dist/ionic-multiselect.js
@@ -304,7 +304,7 @@ angular.module("ionic-multiselect", [])
             var arrChecked = [];
             angular.forEach(scope.defaultValue, function(defaultitem){
                 angular.forEach(scope.items, function(item, key) {
-                if (item.text==defaultitem) {
+                if (item[scope.valueProperty]==defaultitem) {
                   scope.value[key] = scope.getItemValue(item);
                   item.checked=true;
                   arrChecked.push(item);


### PR DESCRIPTION
Actual default-value functionality is not working.
In the scope.fetchCheckedDefaultItems method the item.text property doesn't exist as it is, so any default-value label will be matched (and initially set in the scope). A direct fix would be at least to use item.textProperty instead.
But much better is to base the default-value strategy on the scope.valueProperty instead (of the textProperty).
Consequent documentation is also updated